### PR TITLE
Update get_next_line_bonus.c

### DIFF
--- a/get_next_line_bonus.c
+++ b/get_next_line_bonus.c
@@ -60,6 +60,7 @@ char	*ft_read_to_left_str(int fd, char *left_str)
 		if (rd_bytes == -1)
 		{
 			free(buff);
+			free(left_str);
 			return (NULL);
 		}
 		buff[rd_bytes] = '\0';


### PR DESCRIPTION
It was not freeing the left_str when a file having a null line. Now francinette tester work for this file.